### PR TITLE
Read Open States from Excels (#1557)

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
@@ -9,6 +9,7 @@ import emu.grasscutter.command.CommandHandler;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.PlayerProperty;
 import emu.grasscutter.game.tower.TowerLevelRecord;
+import emu.grasscutter.server.packet.send.PacketOpenStateChangeNotify;
 
 @Command(label = "setProp", aliases = {"prop"}, usage = {"<prop> <value>"}, permission = "player.setprop", permissionTargeted = "player.setprop.others")
 public final class SetPropCommand implements CommandHandler {
@@ -19,7 +20,9 @@ public final class SetPropCommand implements CommandHandler {
         BP_LEVEL,
         GOD_MODE,
         NO_STAMINA,
-        UNLIMITED_ENERGY
+        UNLIMITED_ENERGY,
+        SET_OPENSTATE,
+        UNSET_OPENSTATE
     }
 
     static class Prop {
@@ -90,6 +93,14 @@ public final class SetPropCommand implements CommandHandler {
         Prop unlimitedenergy = new Prop("unlimitedenergy", PseudoProp.UNLIMITED_ENERGY);
         this.props.put("unlimitedenergy", unlimitedenergy);
         this.props.put("ue", unlimitedenergy);
+
+        Prop setopenstate = new Prop("setopenstate", PseudoProp.SET_OPENSTATE);
+        this.props.put("setopenstate", setopenstate);
+        this.props.put("so", setopenstate);
+
+        Prop unsetopenstate = new Prop("unsetopenstate", PseudoProp.UNSET_OPENSTATE);
+        this.props.put("unsetopenstate", unsetopenstate);
+        this.props.put("uo", unsetopenstate);
     }
 
     @Override
@@ -126,6 +137,8 @@ public final class SetPropCommand implements CommandHandler {
             case BP_LEVEL -> targetPlayer.getBattlePassManager().setLevel(value);
             case TOWER_LEVEL -> this.setTowerLevel(sender, targetPlayer, value);
             case GOD_MODE, NO_STAMINA, UNLIMITED_ENERGY -> this.setBool(sender, targetPlayer, prop.pseudoProp, value);
+            case SET_OPENSTATE -> this.setOpenState(targetPlayer, value, 1);
+            case UNSET_OPENSTATE -> this.setOpenState(targetPlayer, value, 0);
             default -> targetPlayer.setProperty(prop.prop, value);
         };
 
@@ -200,6 +213,11 @@ public final class SetPropCommand implements CommandHandler {
             default:
                 return false;
         }
+        return true;
+    }
+
+    private boolean setOpenState(Player targetPlayer, int state, int value) {
+        targetPlayer.sendPacket(new PacketOpenStateChangeNotify(state, value));
         return true;
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/UnlockAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/UnlockAllCommand.java
@@ -2,8 +2,9 @@ package emu.grasscutter.command.commands;
 
 import emu.grasscutter.command.Command;
 import emu.grasscutter.command.CommandHandler;
+import emu.grasscutter.data.GameData;
 import emu.grasscutter.game.player.Player;
-import emu.grasscutter.game.props.OpenState;
+import emu.grasscutter.game.player.PlayerOpenStateManager;
 import emu.grasscutter.server.packet.send.PacketOpenStateChangeNotify;
 
 import java.util.HashMap;
@@ -18,13 +19,16 @@ public final class UnlockAllCommand implements CommandHandler {
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
         Map<Integer, Integer> changed = new HashMap<>();
-        
-        for (OpenState state : OpenState.values()) {
-            if (state == OpenState.OPEN_STATE_NONE || state == OpenState.OPEN_STATE_LIMIT_REGION_GLOBAL) continue;
-            
-            if (targetPlayer.getOpenStateManager().getOpenStateMap().getOrDefault(state.getValue(), 0) == 0) {
-                targetPlayer.getOpenStateManager().getOpenStateMap().put(state.getValue(), 1); 
-                changed.put(state.getValue(), 1);
+
+        for (var state : GameData.getOpenStateList()) {
+            // Don't unlock blacklisted open states.
+            if (PlayerOpenStateManager.BLACKLIST_OPEN_STATES.contains(state.getId())) {
+                continue;
+            }
+
+            if (targetPlayer.getOpenStateManager().getOpenState(state.getId()) == 0) {
+                targetPlayer.getOpenStateManager().getOpenStateMap().put(state.getId(), 1); 
+                changed.put(state.getId(), 1);
             }
         }
         

--- a/src/main/java/emu/grasscutter/data/GameData.java
+++ b/src/main/java/emu/grasscutter/data/GameData.java
@@ -109,10 +109,13 @@ public class GameData {
     @Getter private static final Int2ObjectMap<PersonalLineData> personalLineDataMap = new Int2ObjectOpenHashMap<>();
     @Getter private static final Int2ObjectMap<ChapterData> chapterDataMap = new Int2ObjectOpenHashMap<>();
 
+    @Getter private static final Int2ObjectMap<OpenStateData> openStateDataMap = new Int2ObjectOpenHashMap<>();
+
 	// Cache
 	private static Map<Integer, List<Integer>> fetters = new HashMap<>();
 	private static Map<Integer, List<ShopGoodsData>> shopGoods = new HashMap<>();
 	private static final IntList scenePointIdList = new IntArrayList();
+	@Getter private static final List<OpenStateData> openStateList = new ArrayList<>();
 	
 	public static Int2ObjectMap<?> getMapByResourceDef(Class<?> resourceDefinition) {
 		Int2ObjectMap<?> map = null;

--- a/src/main/java/emu/grasscutter/data/excels/OpenStateData.java
+++ b/src/main/java/emu/grasscutter/data/excels/OpenStateData.java
@@ -1,13 +1,60 @@
-package emu.grasscutter.game.props;
+package emu.grasscutter.data.excels;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Stream;
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.GameResource;
+import emu.grasscutter.data.ResourceType;
+import lombok.AccessLevel;
+import lombok.Getter;
 
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
-public enum OpenState {
+@ResourceType(name = "OpenStateConfigData.json", loadPriority = ResourceType.LoadPriority.HIGHEST)
+public class OpenStateData extends GameResource {
+    private int id;
+    @Getter private boolean defaultState;
+    @Getter private boolean allowClientOpen;
+    @Getter private int systemOpenUiId;
+    @Getter private List<OpenStateCond> cond;
+
+    public static class OpenStateCond {
+        @Getter private OpenStateCondType condType;
+        @Getter private int param;
+        @Getter private int param2;
+    }
+
+    public static enum OpenStateCondType {
+        OPEN_STATE_COND_PLAYER_LEVEL,
+        OPEN_STATE_COND_QUEST,
+        OPEN_STATE_OFFERING_LEVEL,
+        OPEN_STATE_CITY_REPUTATION_LEVEL,
+        OPEN_STATE_COND_PARENT_QUEST;
+    }
+
+    @Override
+    public int getId() {
+        return this.id;
+    }
+
+    @Override
+    public void onLoad() {
+        // Add this open state to the global list.
+        GameData.getOpenStateList().add(this);
+
+        // Clean up cond.
+        List<OpenStateCond> cleanedConds = new ArrayList<>();
+        for (var c : this.cond) {
+            if (c.getCondType() != null) {
+                cleanedConds.add(c);
+            }
+        }
+
+        this.cond = cleanedConds;
+    }
+}
+
+/* Open state names for documentation:
     OPEN_STATE_NONE (0),
     OPEN_STATE_PAIMON (1),
     OPEN_STATE_PAIMON_NAVIGATION (2),
@@ -38,16 +85,16 @@ public enum OpenState {
     OPEN_STATE_GUIDE_TALENT (27),
     OPEN_STATE_GUIDE_RELIC (28),
     OPEN_STATE_GUIDE_RELIC_PROM (29),
-    OPEN_STATE_COMBINE (30, 2),
+    OPEN_STATE_COMBINE (30),
     OPEN_STATE_GACHA (31),
     OPEN_STATE_GUIDE_GACHA (32),
     OPEN_STATE_GUIDE_TEAM (33),
     OPEN_STATE_GUIDE_PROUD (34),
     OPEN_STATE_GUIDE_AVATAR_PROMOTE (35),
     OPEN_STATE_GUIDE_ADVENTURE_CARD (36),
-    OPEN_STATE_FORGE (37, 2),
+    OPEN_STATE_FORGE (37),
     OPEN_STATE_GUIDE_BAG (38),
-    OPEN_STATE_EXPEDITION (39, 14),
+    OPEN_STATE_EXPEDITION (39),
     OPEN_STATE_GUIDE_ADVENTURE_DAILYTASK (40),
     OPEN_STATE_GUIDE_ADVENTURE_DUNGEON (41),
     OPEN_STATE_TOWER (42),
@@ -56,11 +103,11 @@ public enum OpenState {
     OPEN_STATE_RESIN (45),
     OPEN_STATE_LIMIT_REGION_FRESHMEAT (47),
     OPEN_STATE_LIMIT_REGION_GLOBAL (48),
-    OPEN_STATE_MULTIPLAYER (49, 16),
+    OPEN_STATE_MULTIPLAYER (49),
     OPEN_STATE_GUIDE_MOUSEPC (50),
     OPEN_STATE_GUIDE_MULTIPLAYER (51),
     OPEN_STATE_GUIDE_DUNGEONREWARD (52),
-    OPEN_STATE_GUIDE_BLOSSOM (53, 8),
+    OPEN_STATE_GUIDE_BLOSSOM (53),
     OPEN_STATE_AVATAR_FASHION (54),
     OPEN_STATE_PHOTOGRAPH (55),
     OPEN_STATE_GUIDE_KSLQUEST (56),
@@ -97,40 +144,40 @@ public enum OpenState {
     OPEN_STATE_GUIDE_CHANNELLERSLAB_EQUIP_V2 (87),
     OPEN_STATE_GUIDE_CHANNELLERSLAB_MP_SOLUTION_V2 (88),
     OPEN_STATE_GUIDE_CHANNELLERSLAB_POWER_V2 (89),
-    OPEN_STATE_GUIDE_QUICK_TEAMMEMBERCHANGE (90), // Mobile only
+    OPEN_STATE_GUIDE_QUICK_TEAMMEMBERCHANGE (90),
     OPEN_STATE_GGUIDE_FIRSTSHOW (91),
     OPEN_STATE_GGUIDE_MAINPAGE_ENTRY_DISAPPEAR (92),
     OPEN_STATE_CITY_REPUATION_MENGDE (800),
     OPEN_STATE_CITY_REPUATION_LIYUE (801),
-    OPEN_STATE_CITY_REPUATION_UI_HINT (802, 25),
+    OPEN_STATE_CITY_REPUATION_UI_HINT (802),
     OPEN_STATE_CITY_REPUATION_INAZUMA (803),
     OPEN_STATE_SHOP_TYPE_MALL (900),
-    OPEN_STATE_SHOP_TYPE_RECOMMANDED (901, 1),
-    OPEN_STATE_SHOP_TYPE_GENESISCRYSTAL (902, 1),
-    OPEN_STATE_SHOP_TYPE_GIFTPACKAGE (903, 1),
+    OPEN_STATE_SHOP_TYPE_RECOMMANDED (901),
+    OPEN_STATE_SHOP_TYPE_GENESISCRYSTAL (902),
+    OPEN_STATE_SHOP_TYPE_GIFTPACKAGE (903),
     OPEN_STATE_SHOP_TYPE_PAIMON (1001),
     OPEN_STATE_SHOP_TYPE_CITY (1002),
     OPEN_STATE_SHOP_TYPE_BLACKSMITH (1003),
-    OPEN_STATE_SHOP_TYPE_GROCERY (1004, 5),
-    OPEN_STATE_SHOP_TYPE_FOOD (1005, 5),
-    OPEN_STATE_SHOP_TYPE_SEA_LAMP (1006, 13),
+    OPEN_STATE_SHOP_TYPE_GROCERY (1004),
+    OPEN_STATE_SHOP_TYPE_FOOD (1005),
+    OPEN_STATE_SHOP_TYPE_SEA_LAMP (1006),
     OPEN_STATE_SHOP_TYPE_VIRTUAL_SHOP (1007),
-    OPEN_STATE_SHOP_TYPE_LIYUE_GROCERY (1008, 5),
+    OPEN_STATE_SHOP_TYPE_LIYUE_GROCERY (1008),
     OPEN_STATE_SHOP_TYPE_LIYUE_SOUVENIR (1009),
-    OPEN_STATE_SHOP_TYPE_LIYUE_RESTAURANT (1010, 5),
+    OPEN_STATE_SHOP_TYPE_LIYUE_RESTAURANT (1010),
     OPEN_STATE_SHOP_TYPE_INAZUMA_SOUVENIR (1011),
     OPEN_STATE_SHOP_TYPE_NPC_TOMOKI (1012),
     OPEN_STATE_SHOP_TYPE_INAZUMA_SOUVENIR_BLACK_BAR (1013),
     OPEN_ADVENTURE_MANUAL (1100),
     OPEN_ADVENTURE_MANUAL_CITY_MENGDE (1101),
     OPEN_ADVENTURE_MANUAL_CITY_LIYUE (1102),
-    OPEN_ADVENTURE_MANUAL_MONSTER (1103, 8),
+    OPEN_ADVENTURE_MANUAL_MONSTER (1103),
     OPEN_ADVENTURE_MANUAL_BOSS_DUNGEON (1104),
     OPEN_STATE_ACTIVITY_SEALAMP (1200),
     OPEN_STATE_ACTIVITY_SEALAMP_TAB2 (1201),
     OPEN_STATE_ACTIVITY_SEALAMP_TAB3 (1202),
-    OPEN_STATE_BATTLE_PASS (1300, 1),
-    OPEN_STATE_BATTLE_PASS_ENTRY (1301, 20),
+    OPEN_STATE_BATTLE_PASS (1300),
+    OPEN_STATE_BATTLE_PASS_ENTRY (1301),
     OPEN_STATE_ACTIVITY_CRUCIBLE (1400),
     OPEN_STATE_ACTIVITY_NEWBEEBOUNS_OPEN (1401),
     OPEN_STATE_ACTIVITY_NEWBEEBOUNS_CLOSE (1402),
@@ -139,27 +186,27 @@ public enum OpenState {
     OPEN_STATE_LIYUE_INFUSEDCRYSTAL (1405),
     OPEN_STATE_SNOW_MOUNTAIN_ELDER_TREE (1406),
     OPEN_STATE_MIRACLE_RING (1407),
-    OPEN_STATE_COOP_LINE (1408, 26),
+    OPEN_STATE_COOP_LINE (1408),
     OPEN_STATE_INAZUMA_INFUSEDCRYSTAL (1409),
     OPEN_STATE_FISH (1410),
     OPEN_STATE_GUIDE_SUMO_TEAM_SKILL (1411),
     OPEN_STATE_GUIDE_FISH_RECIPE (1412),
     OPEN_STATE_HOME (1500),
-    OPEN_STATE_ACTIVITY_HOMEWORLD (1501, 28),
+    OPEN_STATE_ACTIVITY_HOMEWORLD (1501),
     OPEN_STATE_ADEPTIABODE (1502),
     OPEN_STATE_HOME_AVATAR (1503),
     OPEN_STATE_HOME_EDIT (1504),
     OPEN_STATE_HOME_EDIT_TIPS (1505),
-    OPEN_STATE_RELIQUARY_DECOMPOSE (1600, 45),
-    OPEN_STATE_ACTIVITY_H5 (1700, 10),
+    OPEN_STATE_RELIQUARY_DECOMPOSE (1600),
+    OPEN_STATE_ACTIVITY_H5 (1700),
     OPEN_STATE_ORAIONOKAMI (2000),
     OPEN_STATE_GUIDE_CHESS_MISSION_CHECK (2001),
     OPEN_STATE_GUIDE_CHESS_BUILD (2002),
     OPEN_STATE_GUIDE_CHESS_WIND_TOWER_CIRCLE (2003),
     OPEN_STATE_GUIDE_CHESS_CARD_SELECT (2004),
     OPEN_STATE_INAZUMA_MAINQUEST_FINISHED (2005),
-    OPEN_STATE_PAIMON_LVINFO (2100, 7),
-    OPEN_STATE_TELEPORT_HUD (2101, 2),
+    OPEN_STATE_PAIMON_LVINFO (2100),
+    OPEN_STATE_TELEPORT_HUD (2101),
     OPEN_STATE_GUIDE_MAP_UNLOCK (2102),
     OPEN_STATE_GUIDE_PAIMON_LVINFO (2103),
     OPEN_STATE_GUIDE_AMBORTRANSPORT (2104),
@@ -177,7 +224,7 @@ public enum OpenState {
     OPEN_STATE_GUIDE_POTION_CONFIGURE (2401),
     OPEN_STATE_GUIDE_LANV2_FIREWORK (2402),
     OPEN_STATE_LOADINGTIPS_ENKANOMIYA (2403),
-    OPEN_STATE_MICHIAE_CASKET (2500, 30),
+    OPEN_STATE_MICHIAE_CASKET (2500),
     OPEN_STATE_MAIL_COLLECT_UNLOCK_RED_POINT (2501),
     OPEN_STATE_LUMEN_STONE (2600),
     OPEN_STATE_GUIDE_CRYSTALLINK_BUFF (2601),
@@ -188,41 +235,4 @@ public enum OpenState {
     OPEN_STATE_GUIDE_ROBOTGACHA (2704),
     OPEN_STATE_GUIDE_FRAGILE_RESIN (2800),
     OPEN_ADVENTURE_MANUAL_EDUCATION (2801);
-
-    private final int value;
-    private final int unlockLevel;
-    private static final Int2ObjectMap<OpenState> map = new Int2ObjectOpenHashMap<>();
-    private static final Map<String, OpenState> stringMap = new HashMap<>();
-
-    static {
-        Stream.of(values()).forEach(e -> {
-            map.put(e.getValue(), e);
-            stringMap.put(e.name(), e);
-        });
-    }
-
-    private OpenState(int value) {
-        this.value = value;
-        this.unlockLevel = -1;
-    }
-    private OpenState(int value, int unlockLevel) {
-        this.value = value;
-        this.unlockLevel = unlockLevel;
-    }
-
-    public int getValue() {
-        return value;
-    }
-
-    public int getUnlockLevel() {
-        return this.unlockLevel;
-    }
-
-    public static OpenState getTypeByValue(int value) {
-        return map.getOrDefault(value, OPEN_STATE_NONE);
-    }
-
-    public static OpenState getTypeByName(String name) {
-        return stringMap.getOrDefault(name, OPEN_STATE_NONE);
-    }
-}
+ */

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -435,8 +435,8 @@ public class Player {
             this.updateWorldLevel();
             this.updateProfile();
 
-            // Handle OpenState unlocks from level-up.
-            this.getOpenStateManager().unlockLevelDependentStates();
+            // Handle open state unlocks from level-up.
+            this.getOpenStateManager().tryUnlockOpenStates();
 
             return true;
         }
@@ -1342,9 +1342,6 @@ public class Player {
         this.forgingManager.sendForgeDataNotify();
         this.resinManager.onPlayerLogin();
         this.cookingManager.sendCookDataNofity();
-
-        // Unlock in case this is an existing user that reached a level before we implemented unlocking.
-        this.getOpenStateManager().unlockLevelDependentStates();
         this.getOpenStateManager().onPlayerLogin();
 
         getTodayMoonCard(); // The timer works at 0:0, some users log in after that, use this method to check if they have received a reward today or not. If not, send the reward.

--- a/src/main/java/emu/grasscutter/game/player/PlayerOpenStateManager.java
+++ b/src/main/java/emu/grasscutter/game/player/PlayerOpenStateManager.java
@@ -1,73 +1,157 @@
 package emu.grasscutter.game.player;
 
 import dev.morphia.annotations.Entity;
-import dev.morphia.annotations.Transient;
-import emu.grasscutter.Grasscutter;
-import emu.grasscutter.game.player.Player;
-import emu.grasscutter.game.props.OpenState;
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.excels.OpenStateData;
+import emu.grasscutter.data.excels.OpenStateData.OpenStateCondType;
+import emu.grasscutter.net.proto.RetcodeOuterClass.Retcode;
 import emu.grasscutter.server.packet.send.PacketOpenStateChangeNotify;
 import emu.grasscutter.server.packet.send.PacketOpenStateUpdateNotify;
-import lombok.Getter;
+import emu.grasscutter.server.packet.send.PacketSetOpenStateRsp;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static emu.grasscutter.game.props.OpenState.*;
 
 @Entity
 public class PlayerOpenStateManager extends BasePlayerDataManager {
-    // Map of all open states that this player has. Do not put default values here.
+    // Set of open states that are never unlocked, whether they fulfill the conditions or not.
+    public static final Set<Integer> BLACKLIST_OPEN_STATES = Set.of(
+    48      // blacklist OPEN_STATE_LIMIT_REGION_GLOBAL to make Meledy happy. =D Remove this as soon as quest unlocks are fully implemented.
+    );
+
+    // Set of open states that are set per default for all accounts. Can be overwritten by an entry in `map`.
+    public static final Set<Integer> DEFAULT_OPEN_STATES = GameData.getOpenStateList().stream()
+        .filter(s -> 
+            s.isDefaultState()      // Actual default-opened states.
+            || (s.getCond().stream().filter(c -> c.getCondType() == OpenStateCondType.OPEN_STATE_COND_PLAYER_LEVEL).count() == 0) // All states whose unlock we don't handle correctly yet.
+            || s.getId() == 1 // Always unlock OPEN_STATE_PAIMON, otherwise the player will not have a working chat.
+        )
+        .filter(s -> !BLACKLIST_OPEN_STATES.contains(s.getId()))    // Filter out states in the blacklist.
+        .map(s -> s.getId())
+        .collect(Collectors.toSet());
+
+    // Map of all open states that this player has.
     private Map<Integer, Integer> map;
 
-     /*
-    //DO NOT MODIFY. Based on conversation of official server and client, game version 2.7
-    private static Set<OpenState> newPlayerOpenStates = Set.of(OPEN_STATE_DERIVATIVE_MALL,OPEN_STATE_PHOTOGRAPH,OPEN_STATE_BATTLE_PASS,OPEN_STATE_SHOP_TYPE_GENESISCRYSTAL,OPEN_STATE_SHOP_TYPE_RECOMMANDED,
-        OPEN_STATE_SHOP_TYPE_GIFTPACKAGE,OPEN_STATE_GUIDE_RELIC_PROM,OPEN_STATE_GUIDE_TALENT,OPEN_STATE_SHOP_TYPE_BLACKSMITH,OPEN_STATE_SHOP_TYPE_PAIMON,OPEN_STATE_WEAPON_AWAKEN,
-        OPEN_STATE_WEAPON_PROMOTE,OPEN_STATE_AVATAR_PROMOTE,OPEN_STATE_AVATAR_TALENT,OPEN_STATE_WEAPON_UPGRADE,OPEN_STATE_RESIN,OPEN_STATE_RELIQUARY_UPGRADE,
-        OPEN_STATE_SHOP_TYPE_VIRTUAL_SHOP,OPEN_STATE_RELIQUARY_PROMOTE);
-    */
-
-    // For development. Remove entry when properly implemented
-    // TODO - Set as boolean in OpenState
-    public static final Set<OpenState> DEV_OPEN_STATES = Stream.of(OpenState.values())
-        .filter(s -> s != OpenState.OPEN_STATE_NONE && s.getUnlockLevel() <= 1)
-        .collect(Collectors.toSet());
-    
     public PlayerOpenStateManager(Player player) {
         super(player);
     }
 
-    public Map<Integer, Integer> getOpenStateMap() {
-        if (this.map == null) this.map = new HashMap<>();
+    public synchronized Map<Integer, Integer> getOpenStateMap() {
+        // If no map currently exists, we create one.
+        if (this.map == null) {
+            this.map = new HashMap<>();
+        }
+        
         return this.map;
     }
 
-    public int getOpenState(OpenState openState) {
-        return getOpenStateMap().getOrDefault(openState.getValue(), 0);
+    /**********
+        Direct getters and setters for open states.
+    **********/
+    public int getOpenState(int openState) {
+        return getOpenStateMap().getOrDefault(openState, 0);
     }
 
-    public void setOpenState(OpenState openState, Integer value) {
-        Integer previousValue = getOpenStateMap().getOrDefault(openState.getValue(),0);
+    private void setOpenState(int openState, int value, boolean sendNotify) {
+        int previousValue = this.getOpenStateMap().getOrDefault(openState, 0);
+
         if (value != previousValue) {
-            this.map.put(openState.getValue(), value);
-            player.getSession().send(new PacketOpenStateChangeNotify(openState.getValue(),value));
+            this.getOpenStateMap().put(openState, value);
+
+            if (sendNotify) {
+                player.getSession().send(new PacketOpenStateChangeNotify(openState, value));
+            }
         }
     }
-
-    public void setOpenStates(Map<OpenState,Integer> openStatesChanged) {
-        for (Map.Entry<OpenState, Integer> entry : openStatesChanged.entrySet()) {
-            setOpenState(entry.getKey(), entry.getValue());
-        }
+    private void setOpenState(int openState, int value) {
+        this.setOpenState(openState, value, true);
     }
 
+    /**********
+        Condition checking for setting open states.
+    **********/
+    private boolean areConditionsMet(OpenStateData openState) {
+        // Check all conditions and test if at least one of them is violated.
+        for (var condition : openState.getCond()) {
+            // For level conditions, check if the player has reached the necessary level.
+            if (condition.getCondType() == OpenStateCondType.OPEN_STATE_COND_PLAYER_LEVEL) {
+                if (this.player.getLevel() < condition.getParam()) {
+                    return false;
+                }
+            }
+            else if (condition.getCondType() == OpenStateCondType.OPEN_STATE_COND_QUEST) {
+                // ToDo: Implement.
+            }
+            else if (condition.getCondType() == OpenStateCondType.OPEN_STATE_COND_PARENT_QUEST) {
+                // ToDo: Implement.
+            }
+            else if (condition.getCondType() == OpenStateCondType.OPEN_STATE_OFFERING_LEVEL) {
+                // ToDo: Implement.
+            }
+            else if (condition.getCondType() == OpenStateCondType.OPEN_STATE_CITY_REPUTATION_LEVEL) {
+                // ToDo: Implement.
+            }
+        }
+        
+        // Done. If we didn't find any violations, all conditions are met.
+        return true;
+    }
+
+    /**********
+        Setting open states from the client (via `SetOpenStateReq`).
+    **********/
+    public void setOpenStateFromClient(int openState, int value) {
+        // Get the data for this open state.
+        OpenStateData data = GameData.getOpenStateDataMap().get(openState);
+        if (data == null) {
+            this.player.sendPacket(new PacketSetOpenStateRsp(Retcode.RET_FAIL));
+            return;
+        }
+
+        // Make sure that this is an open state that the client is allowed to set,
+        // and that it doesn't have any further conditions attached.
+        if (!data.isAllowClientOpen() || !this.areConditionsMet(data)) {
+            this.player.sendPacket(new PacketSetOpenStateRsp(Retcode.RET_FAIL));
+            return;
+        }
+
+        // Set.
+        this.setOpenState(openState, value);
+        this.player.sendPacket(new PacketSetOpenStateRsp(openState, value));
+    }
+
+    /**********
+        Handler for player login.
+    **********/
     public void onPlayerLogin() {
+        // Try unlocking open states on player login. This handles accounts where unlock conditions were
+        // already met before certain open state unlocks were implemented.
+        this.tryUnlockOpenStates(false);
+
+        // Send notify to the client.
         player.getSession().send(new PacketOpenStateUpdateNotify(this));
     }
 
-    public void unlockLevelDependentStates() {
-        Stream.of(OpenState.values())
-            .filter(s -> s.getUnlockLevel() > 1 && s.getUnlockLevel() <= this.player.getLevel())
-            .forEach(s -> this.setOpenState(s, 1));
+    /**********
+        Triggered unlocking of open states (unlock states whose conditions have been met.)
+    **********/
+    public void tryUnlockOpenStates(boolean sendNotify) {
+        // Get list of open states that are not yet unlocked.
+        var lockedStates = GameData.getOpenStateList().stream().filter(s -> this.getOpenStateMap().getOrDefault(s, 0) == 0).toList();
+
+        // Try unlocking all of them.
+        for (var state : lockedStates) {
+            // To auto-unlock a state, it has to meet three conditions:
+            // * it can not be a state that is unlocked by the client,
+            // * it has to meet all its unlock conditions, and
+            // * it can not be in the blacklist.
+            if (!state.isAllowClientOpen() && this.areConditionsMet(state) && !BLACKLIST_OPEN_STATES.contains(state.getId())) {
+                this.setOpenState(state.getId(), 1, sendNotify);
+            }
+        }
+    }
+    public void tryUnlockOpenStates() {
+        this.tryUnlockOpenStates(true);
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerSetOpenStateReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerSetOpenStateReq.java
@@ -1,26 +1,19 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.game.props.OpenState;
 import emu.grasscutter.net.packet.Opcodes;
 import emu.grasscutter.net.packet.PacketHandler;
 import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.net.proto.SetOpenStateReqOuterClass.SetOpenStateReq;
 import emu.grasscutter.server.game.GameSession;
-import emu.grasscutter.server.packet.send.PacketSetOpenStateRsp;
 
 @Opcodes(PacketOpcodes.SetOpenStateReq)
 public class HandlerSetOpenStateReq extends PacketHandler {
-
     @Override
     public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
         var req = SetOpenStateReq.parseFrom(payload);
         int openState = req.getKey();
         int value = req.getValue();
 
-        session.getPlayer().getOpenStateManager().setOpenState(OpenState.getTypeByValue(openState), value);
-        //Client Automatically Updates its OpenStateMap, no need to send OpenStateUpdateNotify
-
-        session.send(new PacketSetOpenStateRsp(openState,value));
+        session.getPlayer().getOpenStateManager().setOpenStateFromClient(openState, value);
     }
-
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketOpenStateUpdateNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketOpenStateUpdateNotify.java
@@ -1,7 +1,8 @@
 package emu.grasscutter.server.packet.send;
 
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.excels.OpenStateData;
 import emu.grasscutter.game.player.PlayerOpenStateManager;
-import emu.grasscutter.game.props.OpenState;
 import emu.grasscutter.net.packet.BasePacket;
 import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.net.proto.OpenStateUpdateNotifyOuterClass.OpenStateUpdateNotify;
@@ -17,16 +18,17 @@ public class PacketOpenStateUpdateNotify extends BasePacket {
 
         OpenStateUpdateNotify.Builder proto = OpenStateUpdateNotify.newBuilder();
 
-        for (OpenState state : OpenState.values()) {
+        for (OpenStateData state : GameData.getOpenStateList()) {
             // If the player has an open state stored in their map, then it would always override any default value
-            if (manager.getOpenStateMap().containsKey(state.getValue())) {
-                proto.putOpenStateMap(state.getValue(), manager.getOpenState(state));
-            } else if (PlayerOpenStateManager.DEV_OPEN_STATES.contains(state)) {
-                // Add default value here. TODO properly put default values somewhere
-                proto.putOpenStateMap(state.getValue(), 1);
+            if (manager.getOpenStateMap().containsKey(state.getId())) {
+                proto.putOpenStateMap(state.getId(), manager.getOpenState(state.getId()));
+            }
+            // Otherwise, add the state if it is contained in the set of default open states. 
+            else if (PlayerOpenStateManager.DEFAULT_OPEN_STATES.contains(state.getId())) {
+                proto.putOpenStateMap(state.getId(), 1);
             }
         }
-
+        
         this.setData(proto);
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketSetOpenStateRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketSetOpenStateRsp.java
@@ -2,10 +2,10 @@ package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.net.packet.BasePacket;
 import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.RetcodeOuterClass.Retcode;
 import emu.grasscutter.net.proto.SetOpenStateRspOuterClass.SetOpenStateRsp;
 
 public class PacketSetOpenStateRsp extends BasePacket {
-
     public PacketSetOpenStateRsp(int openState, int value) {
         super(PacketOpcodes.SetOpenStateRsp);
 
@@ -15,4 +15,12 @@ public class PacketSetOpenStateRsp extends BasePacket {
         this.setData(proto);
     }
 
+    public PacketSetOpenStateRsp(Retcode retcode) {
+        super(PacketOpcodes.SetOpenStateRsp);
+
+        SetOpenStateRsp proto = SetOpenStateRsp.newBuilder()
+            .setRetcode(retcode.getNumber()).build();
+
+        this.setData(proto);
+    }
 }

--- a/src/main/java/emu/grasscutter/tools/Dumpers.java
+++ b/src/main/java/emu/grasscutter/tools/Dumpers.java
@@ -4,10 +4,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import emu.grasscutter.game.props.OpenState;
 import emu.grasscutter.net.proto.GetGachaInfoRspOuterClass.GetGachaInfoRsp;
 import emu.grasscutter.net.proto.GetShopRspOuterClass.GetShopRsp;
-import emu.grasscutter.net.proto.OpenStateUpdateNotifyOuterClass.OpenStateUpdateNotify;
 
 public final class Dumpers {
 	public static void extractBanner(byte[] data) throws Exception {
@@ -18,16 +16,5 @@ public final class Dumpers {
 	public static void extractShop(byte[] data) throws Exception {
 		GetShopRsp proto = GetShopRsp.parseFrom(data);
 		System.out.println(proto);
-	}
-	
-	public static void dumpOpenStates(byte[] data) throws Exception {
-		OpenStateUpdateNotify proto = OpenStateUpdateNotify.parseFrom(data);
-		
-		List<Integer> list = new ArrayList<>(proto.getOpenStateMap().keySet());
-		Collections.sort(list);
-		
-		for (int key :  list) {
-			System.out.println(OpenState.getTypeByValue(key) + " : " + key);
-		}
 	}
 }


### PR DESCRIPTION
* Make sure we never access PlayerOpenStateManager::map directly.

* Read OpenStates from excels.

* Add defaultState

* Replace hardcoded open states with the ones read from excels.

* Don't send change notify when unlocking on login.

* Add open state blacklist for default unlocks.

* Add a way to temporarily set open states for dev

* Remove old OpenState.java

* Fix UnlockAllCommand

* Change condType to an enum.

## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My pull request is unique and no other pull requests have been opened for these changes
- [ ] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [ ] I am responsible for any copyright issues with my code if it occurs in the future.